### PR TITLE
Now using `fnmatch.fnmatch` instead of `Path.match` for `ignored` globs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           root: testrepo/test
           head: change_module_a
           base: main
-          ignored: "./modules/a/*"
+          ignored: "modules/a/*"
 
       - name: Do not return workflows
         id: do_not_return_workflows

--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ steps:
 
 ### Ignoring paths
 
-You may want to ignore paths such as docs, strings etc. To do this, specify a list of strings separated by spaces. This supports globbing so use `*` to match multiple.
+You may want to ignore paths such as docs, strings etc. To do this, specify a list of strings separated by spaces. This supports globbing so use `*` to match multiple. Python [fnmatch.fnmatch](https://docs.python.org/3/library/fnmatch.html) is used for matching the ignored paths. Here are some example,
 
-Note: specifying a filename (e.g. `main.nf`) will match all instances of `main.nf`, regardless of directory. If you wish to match a path in the root of the directory use a relative path (`./main.nf`).
+- `.git/*`: Ignore all files and directories inside the `.git` directory
+- `.gitpod.yml`: Ignore `.gitpod.yml` file in the root directory
+- `*.md`: Ignore all the Markdown files
+- `tests/local/*`: Ignore all files and directories inside the `tests/local/` directory
+
+Do not use the relative path (`./`) at the start of the glob pattern as it will nullify the glob matching.
 
 ```yaml
 steps:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ steps:
 
 ### Ignoring paths
 
-You may want to ignore paths such as docs, strings etc. To do this, specify a list of strings separated by spaces. This supports globbing so use `*` to match multiple. Python [fnmatch.fnmatch](https://docs.python.org/3/library/fnmatch.html) is used for matching the ignored paths. Here are some examples,
+You may want to ignore paths such as docs, strings etc. To do this, specify a list of strings separated by spaces. This supports globbing so use `*` to match multiple. Python [fnmatch.fnmatch](https://docs.python.org/3/library/fnmatch.html) is used for matching the ignored paths. Here are some examples:
 
 - `.git/*`: Ignore all files and directories inside the `.git` directory
 - `.gitpod.yml`: Ignore `.gitpod.yml` file in the root directory

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ steps:
 
 ### Ignoring paths
 
-You may want to ignore paths such as docs, strings etc. To do this, specify a list of strings separated by spaces. This supports globbing so use `*` to match multiple. Python [fnmatch.fnmatch](https://docs.python.org/3/library/fnmatch.html) is used for matching the ignored paths. Here are some example,
+You may want to ignore paths such as docs, strings etc. To do this, specify a list of strings separated by spaces. This supports globbing so use `*` to match multiple. Python [fnmatch.fnmatch](https://docs.python.org/3/library/fnmatch.html) is used for matching the ignored paths. Here are some examples,
 
 - `.git/*`: Ignore all files and directories inside the `.git` directory
 - `.gitpod.yml`: Ignore `.gitpod.yml` file in the root directory

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -13,6 +13,7 @@ import logging
 from enum import Enum
 from git import Repo
 from pathlib import Path
+import fnmatch
 
 
 class TestTargetType(Enum):
@@ -419,15 +420,14 @@ def find_changed_files(
 
     # For every file that has changed between commits
     for file in diff_index:
-        logging.debug(f"File found in diff_index: {str(file)}")
         # Get pathlib.Path object
         filepath = Path(file.a_path)
-        logging.debug(f"pathlib.Path object: {str(filepath)}")
+        logging.debug(f"File found in diff_index: {str(filepath)}")
 
         # If file does not match any in the ignore list, add containing directory to changed_files
         match_against_ignored = []
         for ignored_path in ignore:
-            is_matched = filepath.match(ignored_path)
+            is_matched = fnmatch.fnmatch(str(filepath), ignored_path)
             logging.debug(
                 f"Checking match of {str(filepath)} against {str(ignored_path)}: {str(is_matched)}"
             )

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -419,10 +419,20 @@ def find_changed_files(
 
     # For every file that has changed between commits
     for file in diff_index:
+        logging.debug(f"File found in diff_index: {str(file)}")
         # Get pathlib.Path object
         filepath = Path(file.a_path)
+        logging.debug(f"pathlib.Path object: {str(filepath)}")
+
         # If file does not match any in the ignore list, add containing directory to changed_files
-        if not any(filepath.match(ignored_path) for ignored_path in ignore):
+        match_against_ignored = []
+        for ignored_path in ignore:
+            is_matched = filepath.match(ignored_path)
+            logging.debug(
+                f"Checking match of {str(filepath)} against {str(ignored_path)}: {str(is_matched)}"
+            )
+            match_against_ignored.append(is_matched)
+        if not any(match_against_ignored):
             # Prepend the root of the path for better scanning
             changed_files.append(path.joinpath(filepath).resolve())
 


### PR DESCRIPTION
This PR closes https://github.com/adamrtalbot/detect-nf-test-changes/issues/8