### PR TITLE
Bug fix for filter by tag strategy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           ignored: "modules/a/*"
           log_level: DEBUG
 
-      - name: Return directory # Expected: modules/b (depends on A), modules/a
+      - name: Return directory # Expected: modules/a, modules/b (depends on A)
         id: detect_module_a_directory
         uses: ./
         with:
@@ -51,7 +51,7 @@ jobs:
           n_parents: 2
           log_level: DEBUG
 
-      - name: Detect config changes # Expected: tests/main.pipeline.nf.test, subworkflows/a/tests/main.nf.test, tests/main.workflow.nf.test, modules/c/tests/main.nf.test
+      - name: Detect config changes # Expected: modules/c/tests/main.nf.test, subworkflows/a/tests/main.nf.test, tests/main.pipeline.nf.test, tests/main.workflow.nf.test
         id: detect_config_changes
         uses: ./
         with:
@@ -60,7 +60,7 @@ jobs:
           base: main
           log_level: DEBUG
       
-      - name: Do not return workflows # Expected: tests/main.pipeline.nf.test, modules/c/tests/main.nf.test; Same as above but without workflows
+      - name: Do not return workflows # Expected: modules/c/tests/main.nf.test, tests/main.pipeline.nf.test; Same as above but without workflows
         id: do_not_return_workflows
         uses: ./
         with:
@@ -70,7 +70,7 @@ jobs:
           types: "function,process,pipeline"
           log_level: DEBUG
 
-      - name: Detect additional include statement file # Expected: tests/main.workflow.nf.test, tests/main.pipeline.nf.test
+      - name: Detect additional include statement file # Expected: tests/main.pipeline.nf.test, tests/main.workflow.nf.test
         id: detect_additional_include_file
         uses: ./
         with:
@@ -118,16 +118,16 @@ jobs:
           [ '${{ steps.ignore_module_a.outputs.components }}' = '[]' ]
           
           echo Directories: ${{ steps.detect_module_a_directory.outputs.components }}
-          [ '${{ steps.detect_module_a_directory.outputs.components }}' = '["modules/b", "modules/a"]' ]
+          [ '${{ steps.detect_module_a_directory.outputs.components }}' = '["modules/a", "modules/b"]' ]
           
           echo Config files: ${{ steps.detect_config_changes.outputs.components }}
-          [ '${{ steps.detect_config_changes.outputs.components }}' = '["tests/main.pipeline.nf.test", "subworkflows/a/tests/main.nf.test", "tests/main.workflow.nf.test", "modules/c/tests/main.nf.test"]' ]
+          [ '${{ steps.detect_config_changes.outputs.components }}' = '["modules/c/tests/main.nf.test", "subworkflows/a/tests/main.nf.test", "tests/main.pipeline.nf.test", "tests/main.workflow.nf.test"]' ]
           
           echo No workflows: ${{ steps.do_not_return_workflows.outputs.components }}
-          [ '${{ steps.do_not_return_workflows.outputs.components }}' = '["tests/main.pipeline.nf.test", "modules/c/tests/main.nf.test"]' ]
+          [ '${{ steps.do_not_return_workflows.outputs.components }}' = '["modules/c/tests/main.nf.test", "tests/main.pipeline.nf.test"]' ]
           
           echo Additional include file: ${{ steps.detect_additional_include_file.outputs.components }}
-          [ '${{ steps.detect_additional_include_file.outputs.components }}' = '["tests/main.workflow.nf.test", "tests/main.pipeline.nf.test"]' ]
+          [ '${{ steps.detect_additional_include_file.outputs.components }}' = '["tests/main.pipeline.nf.test", "tests/main.workflow.nf.test"]' ]
 
           echo Tags: ${{ steps.detect_tags.outputs.components }}
           [ '${{ steps.detect_tags.outputs.components }}' = '["tests/main.pipeline.nf.test"]' ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Print and assert outputs
         run: |
           echo Default: ${{ steps.detect_module_a_default.outputs.components }}
-          [ '${{ steps.detect_module_a_default.outputs.components }}' = '["modules/a/tests/main.nf.test", "modules/b/tests/main.nf.test"]' ]
+          [ '${{ steps.detect_module_a_default.outputs.components }}' = '["modules/b/tests/main.nf.test"]' ]
           echo Ignore module A: ${{ steps.ignore_module_a.outputs.components }}
           echo No workflows: ${{ steps.do_not_return_workflows.outputs.components }}
           echo Directories: ${{ steps.detect_module_a_directory.outputs.components }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           && tar -xzvf .github/workflows/test.tar.gz -C testrepo --no-same-owner
 
       - name: default
-        id: detect_module_a_default # Expected: modules/a/main.nf, modules/a/tests/main.nf.test
+        id: detect_module_a_default # Expected: modules/a/tests/main.nf.test, modules/b/tests/main.nf.test (depends on A)
         uses: ./
         with:
           root: testrepo/test
@@ -31,7 +31,7 @@ jobs:
           base: main
           log_level: DEBUG
 
-      - name: Ignore changes in module A
+      - name: Ignore changes in module A # Expected: Nothing
         id: ignore_module_a
         uses: ./
         with:
@@ -41,17 +41,7 @@ jobs:
           ignored: "modules/a/*"
           log_level: DEBUG
 
-      - name: Do not return workflows
-        id: do_not_return_workflows
-        uses: ./
-        with:
-          root: testrepo/test
-          head: change_module_a
-          base: main
-          types: "function,process,pipeline"
-          log_level: DEBUG
-
-      - name: Return directory
+      - name: Return directory # Expected: modules/b (depends on A), modules/a
         id: detect_module_a_directory
         uses: ./
         with:
@@ -61,7 +51,7 @@ jobs:
           n_parents: 2
           log_level: DEBUG
 
-      - name: Detect config changes
+      - name: Detect config changes # Expected: tests/main.pipeline.nf.test, subworkflows/a/tests/main.nf.test, tests/main.workflow.nf.test, modules/c/tests/main.nf.test
         id: detect_config_changes
         uses: ./
         with:
@@ -69,8 +59,18 @@ jobs:
           head: modify_nextflow_config_in_module_c
           base: main
           log_level: DEBUG
+      
+      - name: Do not return workflows # Expected: tests/main.pipeline.nf.test, modules/c/tests/main.nf.test; Same as above but without workflows
+        id: do_not_return_workflows
+        uses: ./
+        with:
+          root: testrepo/test
+          head: modify_nextflow_config_in_module_c
+          base: main
+          types: "function,process,pipeline"
+          log_level: DEBUG
 
-      - name: Detect additional include statement file
+      - name: Detect additional include statement file # Expected: tests/main.workflow.nf.test, tests/main.pipeline.nf.test
         id: detect_additional_include_file
         uses: ./
         with:
@@ -79,28 +79,28 @@ jobs:
           base: main
           log_level: DEBUG
 
-      - name: Include tags
+      - name: Include tags # Expected: "tests/main.pipeline.nf.test"
         id: detect_tags
         uses: ./
         with:
           root: testrepo/test
           head: modify_main_nextflow_file
           base: main
-          tags: "PIPELINE" # should pick one test
+          tags: "PIPELINE"
           log_level: DEBUG
 
-      - name: Exclude tags
+      - name: Exclude tags # Expected: Nothing
         id: exclude_tags
         uses: ./
         with:
           root: testrepo/test
           head: modify_main_nextflow_file
           base: main
-          tags: "PIPELINE" # should pick one test
-          exclude_tags: "PIPELINE" # should drop the test
+          tags: "PIPELINE"
+          exclude_tags: "PIPELINE"
           log_level: DEBUG
 
-      - name: Detect multi-line include
+      - name: Detect multi-line include # Expected: subworkflows/a/tests/main.nf.test, tests/main.pipeline.nf.test, tests/main.workflow.nf.test
         id: multi_line_include
         uses: ./
         with:
@@ -112,12 +112,28 @@ jobs:
       - name: Print and assert outputs
         run: |
           echo Default: ${{ steps.detect_module_a_default.outputs.components }}
-          [ '${{ steps.detect_module_a_default.outputs.components }}' = '["modules/b/tests/main.nf.test"]' ]
+          [ '${{ steps.detect_module_a_default.outputs.components }}' = '["modules/a/tests/main.nf.test", "modules/b/tests/main.nf.test"]' ]
+          
           echo Ignore module A: ${{ steps.ignore_module_a.outputs.components }}
-          echo No workflows: ${{ steps.do_not_return_workflows.outputs.components }}
+          [ '${{ steps.ignore_module_a.outputs.components }}' = '[]' ]
+          
           echo Directories: ${{ steps.detect_module_a_directory.outputs.components }}
+          [ '${{ steps.detect_module_a_directory.outputs.components }}' = '["modules/b", "modules/a"]' ]
+          
           echo Config files: ${{ steps.detect_config_changes.outputs.components }}
+          [ '${{ steps.detect_config_changes.outputs.components }}' = '["tests/main.pipeline.nf.test", "subworkflows/a/tests/main.nf.test", "tests/main.workflow.nf.test", "modules/c/tests/main.nf.test"]' ]
+          
+          echo No workflows: ${{ steps.do_not_return_workflows.outputs.components }}
+          [ '${{ steps.do_not_return_workflows.outputs.components }}' = '["tests/main.pipeline.nf.test", "modules/c/tests/main.nf.test"]' ]
+          
           echo Additional include file: ${{ steps.detect_additional_include_file.outputs.components }}
+          [ '${{ steps.detect_additional_include_file.outputs.components }}' = '["tests/main.workflow.nf.test", "tests/main.pipeline.nf.test"]' ]
+
           echo Tags: ${{ steps.detect_tags.outputs.components }}
+          [ '${{ steps.detect_tags.outputs.components }}' = '["tests/main.pipeline.nf.test"]' ]
+
           echo Exclude tags: ${{ steps.exclude_tags.outputs.components }}
+          [ '${{ steps.exclude_tags.outputs.components }}' = '[]' ]
+          
           echo Multi-line include: ${{ steps.multi_line_include.outputs.components }}
+          [ '${{ steps.multi_line_include.outputs.components }}' = '["subworkflows/a/tests/main.nf.test", "tests/main.pipeline.nf.test", "tests/main.workflow.nf.test"]' ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,9 +109,10 @@ jobs:
           base: main
           log_level: DEBUG
 
-      - name: print outputs
+      - name: Print and assert outputs
         run: |
           echo Default: ${{ steps.detect_module_a_default.outputs.components }}
+          [ '${{ steps.detect_module_a_default.outputs.components }}' = '["modules/a/tests/main.nf.test", "modules/b/tests/main.nf.test"]' ]
           echo Ignore module A: ${{ steps.ignore_module_a.outputs.components }}
           echo No workflows: ${{ steps.do_not_return_workflows.outputs.components }}
           echo Directories: ${{ steps.detect_module_a_directory.outputs.components }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           && tar -xzvf .github/workflows/test.tar.gz -C testrepo --no-same-owner
 
       - name: default
-        id: detect_module_a_default
+        id: detect_module_a_default # Expected: modules/a/main.nf, modules/a/tests/main.nf.test
         uses: ./
         with:
           root: testrepo/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
           root: testrepo/test
           head: change_module_a
           base: main
+          log_level: DEBUG
 
       - name: Ignore changes in module A
         id: ignore_module_a
@@ -38,6 +39,7 @@ jobs:
           head: change_module_a
           base: main
           ignored: "modules/a/*"
+          log_level: DEBUG
 
       - name: Do not return workflows
         id: do_not_return_workflows
@@ -47,6 +49,7 @@ jobs:
           head: change_module_a
           base: main
           types: "function,process,pipeline"
+          log_level: DEBUG
 
       - name: Return directory
         id: detect_module_a_directory
@@ -56,6 +59,7 @@ jobs:
           head: change_module_a
           base: main
           n_parents: 2
+          log_level: DEBUG
 
       - name: Detect config changes
         id: detect_config_changes
@@ -64,6 +68,7 @@ jobs:
           root: testrepo/test
           head: modify_nextflow_config_in_module_c
           base: main
+          log_level: DEBUG
 
       - name: Detect additional include statement file
         id: detect_additional_include_file
@@ -72,6 +77,7 @@ jobs:
           root: testrepo/test
           head: modify_main_nextflow_file
           base: main
+          log_level: DEBUG
 
       - name: Include tags
         id: detect_tags
@@ -81,6 +87,7 @@ jobs:
           head: modify_main_nextflow_file
           base: main
           tags: "PIPELINE" # should pick one test
+          log_level: DEBUG
 
       - name: Exclude tags
         id: exclude_tags
@@ -91,6 +98,7 @@ jobs:
           base: main
           tags: "PIPELINE" # should pick one test
           exclude_tags: "PIPELINE" # should drop the test
+          log_level: DEBUG
 
       - name: Detect multi-line include
         id: multi_line_include
@@ -99,6 +107,7 @@ jobs:
           root: testrepo/test
           head: multi_line_include
           base: main
+          log_level: DEBUG
 
       - name: print outputs
         run: |

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -666,15 +666,17 @@ if __name__ == "__main__":
     # Go back n_parents directories, remove root from path and stringify
     # It's a bit much but might as well do all path manipulation in one place
     logging.info("Normalising test file paths")
-    normalised_nf_test_path = list(
-        {
-            str(
-                nf_test.get_parents(args.n_parents)
-                .resolve()
-                .relative_to(root_path.resolve())
-            )
-            for nf_test in only_selected_nf_tests
-        }
+    normalised_nf_test_path = sorted(
+        list(
+            {
+                str(
+                    nf_test.get_parents(args.n_parents)
+                    .resolve()
+                    .relative_to(root_path.resolve())
+                )
+                for nf_test in only_selected_nf_tests
+            }
+        )
     )
 
     # Print to string for outputs

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -548,8 +548,15 @@ if __name__ == "__main__":
     logging.basicConfig(level=args.log_level)
     # Argparse handling of nargs is a bit rubbish. So we do it manually here.
     args.types = args.types.split(",")
-    args.tags = [tag.strip().casefold() for tag in args.tags.split(",")]
-    args.exclude_tags = [tag.strip().casefold() for tag in args.exclude_tags.split(",")]
+
+    if args.tags.strip() != "":
+        args.tags = [tag.strip().casefold() for tag in args.tags.split(",")]
+
+    if args.exclude_tags.strip() != "":
+        args.exclude_tags = [
+            tag.strip().casefold() for tag in args.exclude_tags.split(",")
+        ]
+
     # Quick validation of args.types since we cant do this in argparse
     if any(
         _type not in ["function", "process", "workflow", "pipeline"]


### PR DESCRIPTION
## Changes

1. Fixed bug where everything was filtered when `tags:` and `exclude_tags:` was not specified
2. Added annotations and assertions to the CI.
3. Sorted the output list to ensure that the CI assertions work on repeat tests.


@sateeshperi , @mashehu , @adamrtalbot Kindly check that I have not left a bug in there. 