### PR TITLE
Switch to spaced args for better handling on the CLI

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,13 +4,13 @@ set -eux
 git config --global --add safe.directory '*'
 
 python /entrypoint.py \
-    ${ROOT:+"-p=$ROOT"} \
-    ${HEAD:+"-r=$HEAD"} \
-    ${BASE:+"-b=$BASE"} \
-    ${IGNORED:+"-x=$IGNORED"} \
-    ${INCLUDE:+"-i=$INCLUDE"} \
-    ${LOG_LEVEL:+"--log-level=$LOG_LEVEL"} \
-    ${TYPES:+"-t=$TYPES"} \
-    ${N_PARENTS:+"--n_parents=$N_PARENTS"} \
-    ${TAGS:+"-T=$TAGS"} \
-    ${EXCLUDE_TAGS:+"--exclude_tags=$EXCLUDE_TAGS"}
+    ${ROOT:+"-p $ROOT"} \
+    ${HEAD:+"-r $HEAD"} \
+    ${BASE:+"-b $BASE"} \
+    ${IGNORED:+"-x $IGNORED"} \
+    ${INCLUDE:+"-i $INCLUDE"} \
+    ${LOG_LEVEL:+"--log-level $LOG_LEVEL"} \
+    ${TYPES:+"-t $TYPES"} \
+    ${N_PARENTS:+"--n_parents $N_PARENTS"} \
+    ${TAGS:+"-T $TAGS"} \
+    ${EXCLUDE_TAGS:+"--exclude_tags $EXCLUDE_TAGS"}


### PR DESCRIPTION
the equals sign in the CLI was causing false positive hits: https://github.com/nf-core/rnaseq/pull/1518. This changes it to use spaces which don't have this issue.

Note this is basically deprecated so consider this a last minute patch.